### PR TITLE
README: fix server version and configuration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,16 +41,15 @@ Plug 'bmeneg/coc-perl', {'do': 'yarn install && yarn build'}
 
 As user, you can change and pass different options to the language server, however, the options are tied to the server
 version being used. Because of that, make sure to always run the newest version of Perl::LanguageServer as well or at
-least the version supported here (`2.4.0`), in case the language server moves faster than this project.
+least the version supported here (`2.5.0`), in case the language server moves faster than this project.
 
 The options are placed in the `coc-settings.json` (which can be opened directly issuing `:CocConfig`) and has the following format:
 
 ```json
 {
-    "perl": {
-        "enable": true,
-        "logLevel": 1,
-    }
+    "perl.enable": true,
+    "perl.logFile":  "~/coc-perl.log",
+    "perl.logLevel": 2
 }
 ```
 


### PR DESCRIPTION
coc.nvim configuration file requires the options for the extensions are passed as direct properties instead of objects, with that, this commit fixes the README file to reflect it and also updates the supported server version, 2.5.0.