### PR TITLE
package: follow server version 2.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Plug 'bmeneg/coc-perl', {'do': 'yarn install && yarn build'}
 
 As user, you can change and pass different options to the language server, however, the options are tied to the server
 version being used. Because of that, make sure to always run the newest version of Perl::LanguageServer as well or at
-least the version supported here (`2.5.0`), in case the language server moves faster than this project.
+least the version supported here (`2.6.0`), in case the language server moves faster than this project.
 
 The options are placed in the `coc-settings.json` (which can be opened directly issuing `:CocConfig`) and has the following format:
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "coc-perl",
 	"displayName": "Perl",
 	"description": "Perl Language Server for coc.nvim",
-	"version": "1.2.3",
+	"version": "1.3.0",
 	"author": "bmeneg@heredoc.io",
 	"homepage": "https://github.com/bmeneg/coc-perl",
 	"publisher": "bmeneg <bmeneg@heredoc.io>",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -136,6 +136,11 @@ function buildContainerArgs(
         containerArgs.push(containerMode);
         if (containerMode == 'run') containerArgs.push('--rm');
         containerArgs.push('-i', containerName);
+      } else if (containerCmd == 'podman') {
+        containerArgs.push(containerMode);
+        if (containerMode == 'run')
+          containerArgs.push('--rm');
+        containerArgs.push('-i', containerName);
       } else if (containerCmd == 'docker-compose') {
         containerArgs.push(containerMode);
         if (containerMode == 'run') containerArgs.push('--rm');
@@ -161,7 +166,7 @@ export async function activate(context: ExtensionContext) {
   }
   console.log('extension "perl" is now active');
 
-  const lsVersion = '2.5.0';
+  const lsVersion = '2.6.0';
   const resource = window.activeTextEditor?.document.uri;
   const perlIncOpt = config.perlInc.map((incDir: string): string => {
     return '-I' + resolveWorkspaceFolder(incDir, resource);


### PR DESCRIPTION
The Perl::LanguageServer package got a new release with some important bugfixes. This commit bring the code needed to support this new version.