### PR TITLE
extension: remove trailing spaces

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -138,8 +138,7 @@ function buildContainerArgs(
         containerArgs.push('-i', containerName);
       } else if (containerCmd == 'podman') {
         containerArgs.push(containerMode);
-        if (containerMode == 'run')
-          containerArgs.push('--rm');
+        if (containerMode == 'run') containerArgs.push('--rm');
         containerArgs.push('-i', containerName);
       } else if (containerCmd == 'docker-compose') {
         containerArgs.push(containerMode);


### PR DESCRIPTION
Yarn build process was failing when using warnings as errors for "prettier" due to trailing spaces in a specific file. This commit fixes it.