### PR TITLE
config: rework compat and new config merge

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "coc-perl",
 	"displayName": "Perl",
 	"description": "Client extension for Perl language server through coc.nvim",
-	"version": "2.1.0",
+	"version": "2.1.1",
 	"author": "bmeneg@heredoc.io",
 	"homepage": "https://github.com/bmeneg/coc-perl",
 	"publisher": "Bruno Meneguele <bmeneg@heredoc.io>",

--- a/src/navigator.ts
+++ b/src/navigator.ts
@@ -52,7 +52,7 @@ export function getNavigatorClient(config: INavigatorConfig): LanguageClient {
       { scheme: 'untitled', language: 'perl' },
     ],
     synchronize: {
-      configurationSection: 'perl.navigator',
+      configurationSection: ['perlnavigator', 'perl.navigator'],
     },
   };
 

--- a/src/p_ls.ts
+++ b/src/p_ls.ts
@@ -276,8 +276,8 @@ export async function getPLSClient(
     documentSelector: [{ scheme: 'file', language: 'perl' }],
     revealOutputChannelOn: RevealOutputChannelOn.Never,
     synchronize: {
-      // Synchronize the setting section 'perl_lang' to the server
-      configurationSection: 'perl.p::ls',
+      // Synchronize the settings to the server
+      configurationSection: ['perl', 'perl.p::ls'],
     },
   };
 


### PR DESCRIPTION
Instead of blindly copy the new config format ('perl.p::ls' & 'perl.navigator'), check the workspace and global values before, ensuring that default values from one config doesn't override a value passed by the user. The override behavior was kept as is, meaning that the new format still has precedence over the compat format when both are explicitly defined.

A new release will be created with this commit, since it break user's workflow.