### PR TITLE
config: merge options into a single namespace

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "coc-perl",
 	"displayName": "Perl",
 	"description": "Client extension for Perl language server through coc.nvim",
-	"version": "2.1.1",
+	"version": "2.1.2",
 	"author": "bmeneg@heredoc.io",
 	"homepage": "https://github.com/bmeneg/coc-perl",
 	"publisher": "Bruno Meneguele <bmeneg@heredoc.io>",

--- a/src/navigator.ts
+++ b/src/navigator.ts
@@ -52,7 +52,7 @@ export function getNavigatorClient(config: INavigatorConfig): LanguageClient {
       { scheme: 'untitled', language: 'perl' },
     ],
     synchronize: {
-      configurationSection: ['perlnavigator', 'perl.navigator'],
+      configurationSection: ['perl.navigator'],
     },
   };
 

--- a/src/p_ls.ts
+++ b/src/p_ls.ts
@@ -277,7 +277,7 @@ export async function getPLSClient(
     revealOutputChannelOn: RevealOutputChannelOn.Never,
     synchronize: {
       // Synchronize the settings to the server
-      configurationSection: ['perl', 'perl.p::ls'],
+      configurationSection: ['perl.p::ls'],
     },
   };
 


### PR DESCRIPTION
Since coc-perl must handle different types of config namespace, but for the same server, we need to make sure configurations don't get lost or overriden. The way it was being handled the value on our namespace (`perl.navigator` or `perl.p::ls`) was being overwritten by the original values, a coc-settings.json was being created at workspace level and in some cases terminating with an exception I would not able to debug.

With that, in this commit I reworked the way things are handled, guaranteeing we have all configs under the same namespace and avoiding creating configuration files when not required. The way I do it is by updating every option that is not undefined and is different from both namespaces (eg `perlnavigator` and `perl.navigator`) into our format `perl.navigator` or `perl.p::ls`, check if the value is comming from global or workspace level and passing a single namespace to coc.nvim's client service. At the same time, I added a few additional conditionals before actually updating anything to prevent unnecessary changes to the file and in case of any update.

One additional note is that during development I noticed on `.update()` the actual configuration object is not changed, but only the configuration file, so whenever an update takes place we need to rerun the configuration parse. For that I added a number flag for controlling the do{...}while loop and or'ed it to get a rerun only after all updates were already performed, preventing multiple reruns (one for each update).

Fixes #35 